### PR TITLE
chore(ci): install dependencies for rust builder project

### DIFF
--- a/.github/workflows/flutter-analyze.yml
+++ b/.github/workflows/flutter-analyze.yml
@@ -37,6 +37,10 @@ jobs:
       - name: Install Dependencies
         run: flutter pub get
 
+      - name: Install Dependencies for Rust Builder Project
+        cwd: rust_builder
+        run: flutter pub get
+
       - name: Run Flutter Analyze
         run: flutter analyze
 


### PR DESCRIPTION
The `flutter analyze` workflow has been updated to install dependencies for the `rust_builder` project, ensuring that the analysis process is comprehensive.