### PR TITLE
chore(ci): add dependency installation step for rust builder

### DIFF
--- a/.github/workflows/flutter-analyze.yml
+++ b/.github/workflows/flutter-analyze.yml
@@ -42,6 +42,10 @@ jobs:
         working-directory: rust_builder
         run: flutter pub get
 
+      - name: Install Dependencies for Rust Builder Project
+        working-directory: rust_builder/cargokit/build_tool
+        run: flutter pub get
+
       - name: Run Flutter Analyze
         run: flutter analyze
 


### PR DESCRIPTION
Adds a step to install dependencies for the Rust Builder project within the Flutter analyze workflow. This ensures all necessary packages are available for the analyze process.