### PR TITLE
feat(l10n): add localization for diary operations and data sync

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -128,6 +128,8 @@ PODS:
   - SDWebImageWebPCoder (0.14.6):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
+  - sensors_plus (0.0.1):
+    - Flutter
   - share_plus (0.0.1):
     - Flutter
   - shared_preferences_foundation (0.0.1):
@@ -201,6 +203,7 @@ DEPENDENCIES:
   - rive_common (from `.symlinks/plugins/rive_common/ios`)
   - rust_lib_mood_diary (from `.symlinks/plugins/rust_lib_mood_diary/ios`)
   - screen_brightness_ios (from `.symlinks/plugins/screen_brightness_ios/ios`)
+  - sensors_plus (from `.symlinks/plugins/sensors_plus/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
@@ -286,6 +289,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/rust_lib_mood_diary/ios"
   screen_brightness_ios:
     :path: ".symlinks/plugins/screen_brightness_ios/ios"
+  sensors_plus:
+    :path: ".symlinks/plugins/sensors_plus/ios"
   share_plus:
     :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_foundation:
@@ -342,6 +347,7 @@ SPEC CHECKSUMS:
   screen_brightness_ios: 5ed898fa50fa82a26171c086ca5e28228f932576
   SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
+  sensors_plus: 6a11ed0c2e1d0bd0b20b4029d3bad27d96e0c65b
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -253,5 +253,10 @@
   "weatherSuccess": "Weather acquisition successful",
   "sureToSave": "Are you sure you want to save",
   "drawPickColor": "Pick Color",
-  "audioFileError": "Audio file error"
+  "audioFileError": "Audio file error",
+  "diaryDelete": "Delete",
+  "diaryEdit": "Edit",
+  "diaryShare": "Share",
+  "diaryCount": "{count} Words",
+  "dataSync": "Data sync"
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -253,5 +253,10 @@
   "weatherSuccess": "天气获取成功",
   "sureToSave": "确定保存吗",
   "drawPickColor": "选择颜色",
-  "audioFileError": "音频文件错误"
+  "audioFileError": "音频文件错误",
+  "diaryDelete": "删除",
+  "diaryEdit": "编辑",
+  "diaryShare": "分享",
+  "diaryCount": "{count} 字",
+  "dataSync": "数据同步"
 }

--- a/lib/pages/diary_details/diary_details_view.dart
+++ b/lib/pages/diary_details/diary_details_view.dart
@@ -6,7 +6,9 @@ import 'package:flutter_quill/flutter_quill.dart';
 import 'package:intl/intl.dart';
 import 'package:mood_diary/common/models/isar/diary.dart';
 import 'package:mood_diary/common/values/icons.dart';
+import 'package:mood_diary/components/base/button.dart';
 import 'package:mood_diary/components/mood_icon/mood_icon_view.dart';
+import 'package:mood_diary/main.dart';
 import 'package:mood_diary/utils/data/pref.dart';
 import 'package:mood_diary/utils/theme_util.dart';
 import 'package:refreshed/refreshed.dart';
@@ -90,7 +92,7 @@ class DiaryDetailsPage extends StatelessWidget {
           ],
           buildAChip(
               Text(
-                '${state.diary.contentText.length} 字',
+                l10n.diaryCount(state.diary.contentText.length),
                 style: textStyle.labelLarge!
                     .copyWith(color: colorScheme.onSurface),
               ),
@@ -308,6 +310,7 @@ class DiaryDetailsPage extends StatelessWidget {
                       state.diary.title,
                       style: textStyle.titleMedium,
                     ),
+                    leading: const PageBackButton(),
                     centerTitle: false,
                     flexibleSpace: FlexibleSpaceBar(
                       collapseMode: CollapseMode.pin,
@@ -344,10 +347,13 @@ class DiaryDetailsPage extends StatelessWidget {
                                 onTap: () async {
                                   logic.delete(state.diary);
                                 },
-                                child: const Row(
+                                child: Row(
                                   spacing: 16.0,
                                   mainAxisAlignment: MainAxisAlignment.center,
-                                  children: [Icon(Icons.delete), Text('删除')],
+                                  children: [
+                                    const Icon(Icons.delete_rounded),
+                                    Text(l10n.diaryDelete)
+                                  ],
                                 ),
                               ),
                               const PopupMenuDivider(),
@@ -355,10 +361,13 @@ class DiaryDetailsPage extends StatelessWidget {
                                 onTap: () async {
                                   logic.toEditPage(state.diary);
                                 },
-                                child: const Row(
+                                child: Row(
                                   spacing: 16.0,
                                   mainAxisAlignment: MainAxisAlignment.center,
-                                  children: [Icon(Icons.edit), Text('编辑')],
+                                  children: [
+                                    const Icon(Icons.edit_rounded),
+                                    Text(l10n.diaryEdit)
+                                  ],
                                 ),
                               ),
                               const PopupMenuDivider(),
@@ -367,10 +376,13 @@ class DiaryDetailsPage extends StatelessWidget {
                               onTap: () async {
                                 logic.toSharePage();
                               },
-                              child: const Row(
+                              child: Row(
                                 spacing: 16.0,
                                 mainAxisAlignment: MainAxisAlignment.center,
-                                children: [Icon(Icons.share), Text('分享')],
+                                children: [
+                                  const Icon(Icons.share_rounded),
+                                  Text(l10n.diaryShare)
+                                ],
                               ),
                             ),
                           ];

--- a/lib/pages/home/diary/diary_view.dart
+++ b/lib/pages/home/diary/diary_view.dart
@@ -54,9 +54,9 @@ class DiaryPage extends StatelessWidget {
     Widget buildTabBar() {
       List<Widget> allTabs = [];
       //默认的全部tab
-      allTabs.add(const Padding(
-        padding: EdgeInsets.symmetric(horizontal: 8.0),
-        child: Tab(text: '全部'),
+      allTabs.add(Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8.0),
+        child: Tab(text: l10n.categoryAll),
       ));
       //根据分类生成分类Tab
       allTabs.addAll(List.generate(state.categoryList.length, (index) {
@@ -222,7 +222,7 @@ class DiaryPage extends StatelessWidget {
                                     },
                                   );
                                 },
-                                tooltip: '数据同步',
+                                tooltip: l10n.dataSync,
                                 icon: const Icon(Icons.cloud_sync_rounded),
                               );
                       }),


### PR DESCRIPTION
- Add `diaryDelete`, `diaryEdit`, `diaryShare`, `diaryCount` and `dataSync` translations to `intl_en.arb` and `intl_zh.arb`.
- Update diary list and diary details to use new localization strings.
- Add `sensors_plus` plugin to Podfile.lock.
- Update `diary_view` with localized strings
- update `diary_details_view` with localized strings