### PR TITLE
chore(*): bump version to 2.7.1+71

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mood_diary
 description: "A new Flutter project."
 publish_to: 'none'
-version: 2.7.0+70
+version: 2.7.1+71
 
 environment:
   sdk: '>=3.6.0'


### PR DESCRIPTION
The version number in `pubspec.yaml` has been updated from `2.7.0+70` to `2.7.1+71`.