### PR TITLE
feat(ui): adjust lock page and correct localization

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -229,7 +229,7 @@
   "editPickAudioFromRecord": "Recording",
   "editPickAudioFromFile": "File Audio",
   "editDateAndTime": "Date and time",
-  "editWeather": "weather",
+  "editWeather": "Weather",
   "editCategory": "Category",
   "editTag": "Tag",
   "editAddTag": "Add tag",

--- a/lib/pages/lock/lock_view.dart
+++ b/lib/pages/lock/lock_view.dart
@@ -88,6 +88,11 @@ class LockPage extends StatelessWidget {
     return PopScope(
       canPop: state.lockType != 'pause',
       child: Scaffold(
+        appBar: AppBar(
+          leading: null,
+          automaticallyImplyLeading: false,
+        ),
+        extendBodyBehindAppBar: true,
         body: Center(
           child: SingleChildScrollView(
             scrollDirection: Axis.vertical,


### PR DESCRIPTION
-   Adjusted the lock page's `AppBar` to remove the leading widget and prevent auto-implication.
-   Made the lock page's `AppBar` to extend behind the body.
-   Corrected the "weather" localization to "Weather".