### PR TITLE
feat(markdown): add support for markdown diary

### DIFF
--- a/lib/components/markdown_bar/markdown_bar.dart
+++ b/lib/components/markdown_bar/markdown_bar.dart
@@ -1,0 +1,708 @@
+import 'package:flutter/material.dart';
+
+import 'parser.dart';
+
+class MarkdownToolbar extends StatefulWidget {
+  /// Creates a [MarkdownToolbar] widget.
+  ///
+  /// The following field is necessary: [useIncludedTextField] (bool)
+  ///
+  /// If you set [useIncludedTextField] to `true`, you are ready to use the Widget with its included TextField.
+  ///
+  /// If you set [useIncludedTextField] to `false`, you need a [TextField] widget outside of
+  /// the [MarkdownToolbar] which has the same [controller] and [focusNode] set as the [MarkdownToolbar] (see below).
+  ///
+  /// Remember: In this case, you have to set the [controller] and [focusNode] fields in your
+  /// [MarkdownToolbar]. Hover over each field for more details on implementing your own TextField correctly.
+  const MarkdownToolbar({
+    super.key,
+    required this.useIncludedTextField,
+    this.controller,
+    this.focusNode,
+    this.collapsable = true,
+    this.alignCollapseButtonEnd = false,
+    this.flipCollapseButtonIcon = false,
+    this.backgroundColor = const Color(0xFFEEEEEE),
+    this.dropdownTextColor = Colors.blue,
+    this.iconColor = const Color(0xFF303030),
+    this.iconSize = 24.0,
+    this.borderRadius = const BorderRadius.all(Radius.circular(6.0)),
+    this.width = 60.0,
+    this.height = 40.0,
+    this.spacing = 4.0,
+    this.runSpacing = 4.0,
+    this.alignment = WrapAlignment.end,
+    this.boldCharacter = '**',
+    this.italicCharacter = '*',
+    this.codeCharacter = '```',
+    this.bulletedListCharacter = '-',
+    this.horizontalRuleCharacter = '---',
+    this.hideHeading = false,
+    this.hideBold = false,
+    this.hideItalic = false,
+    this.hideStrikethrough = false,
+    this.hideLink = false,
+    this.hideImage = false,
+    this.hideCode = false,
+    this.hideBulletedList = false,
+    this.hideNumberedList = false,
+    this.hideCheckbox = false,
+    this.hideQuote = false,
+    this.hideHorizontalRule = false,
+    this.showTooltips = true,
+    this.headingTooltip = 'Heading',
+    this.boldTooltip = 'Bold',
+    this.italicTooltip = 'Italic',
+    this.strikethroughTooltip = 'Strikethrough',
+    this.linkTooltip = 'Link',
+    this.imageTooltip = 'Image',
+    this.codeTooltip = 'Code',
+    this.bulletedListTooltip = 'Bulleted list',
+    this.numberedListTooltip = 'Numbered list',
+    this.checkboxTooltip = 'Checkbox',
+    this.quoteTooltip = 'Quote',
+    this.horizontalRuleTooltip = 'Horizontal rule',
+  });
+
+  /// It is recommended that you use your own TextField outside this widget for more customization.
+  /// To do that, set [useIncludedTextField] to `false` and implement your own TextField outside.
+  /// IMPORTANT: Remember to set the same [controller] and [focusNode] in the TextField as the ones in your [MarkdownToolbar].
+  /// Hover over the 2 fields for more details.
+  ///
+  /// If you want to use the included TextField as a quick solution, set [useIncludedTextField] to `true` and you are ready to go.
+  final bool useIncludedTextField;
+
+  /// In order to use a custom TextField, assign a [TextEditingController] to the [controller] field.
+  /// ```
+  /// final TextEditingController _controller = TextEditingController(); //Declare the TextEditingController
+  /// @override
+  /// void initState() {
+  ///   super.initState();
+  ///   _controller.addListener(() => setState(() {})); //To update the text inside the [controller] add a listener and call setState()
+  /// }
+  /// @override
+  /// void dispose() {
+  ///   _controller.dispose(); //Dispose the TextEditingController in dispose()
+  ///   super.dispose();
+  /// }
+  /// MarkdownToolbar(controller: _controller, ...), //Set the TextEditingController in the toolbar
+  /// TextField(controller: _controller, ...), //Set the same _controller in your TextField
+  /// ```
+  final TextEditingController? controller;
+
+  /// If using a custom TextField, set the [focusNode] to a [FocusNode] Widget in order
+  /// to focus the text after clicking a button. Use the FocusNode like this:
+  /// ```
+  /// late final FocusNode _focusNode; //Declare the FocusNode
+  /// @override
+  /// void initState() {
+  ///   super.initState();
+  ///   _focusNode = FocusNode(); //Assign a new FocusNode in initState()
+  /// }
+  /// @override
+  /// void dispose() {
+  ///   _focusNode.dispose(); //Dispose the FocusNode in dispose()
+  ///   super.dispose();
+  /// }
+  /// MarkdownToolbar(focusNode: _focusNode, ...), //Set the FocusNode in the toolbar
+  /// TextField(focusNode: _focusNode, ...), //Set the same _focusNode in your TextField
+  /// ```
+  final FocusNode? focusNode;
+
+  /// Make the toolbar collapsable with a button by setting [collapsable] to `true`.
+  final bool collapsable;
+
+  /// Align the collapse button at the end. Default: `false`.
+  final bool alignCollapseButtonEnd;
+
+  /// Flip the collapse button icon. Default: `false`.
+  final bool flipCollapseButtonIcon;
+
+  /// Set the [backgroundColor] of the buttons. Default: `Colors.grey[200]`
+  final Color backgroundColor;
+
+  /// Set the [dropdownTextColor] of the buttons. Default: `Colors.blue`
+  final Color dropdownTextColor;
+
+  /// Set the [iconColor] of the buttons. Default: `Colors.grey[850]`
+  final Color iconColor;
+
+  /// Set the [iconSize] of the buttons. Default: `24`
+  final double iconSize;
+
+  /// Set the [borderRadius] of the buttons. Default: `BorderRadius.all(Radius.circular(6.0))`
+  final BorderRadius borderRadius;
+
+  /// Set the [width] of the buttons. Default: `60`.
+  final double width;
+
+  /// Set the [height] of the buttons. Default: `40`.
+  final double height;
+
+  /// Set the horizontal [spacing] of the buttons. Default: `4.0`.
+  final double spacing;
+
+  /// Set the vertical [runSpacing] of the buttons. Default: `4.0`.
+  final double runSpacing;
+
+  /// Set the [WrapAlignment] of the buttons. Default: `WrapAlignment.end`.
+  final WrapAlignment alignment;
+
+  /// If you want to use an alternative bold character (Default: `**`),
+  /// assign a custom [String] to [boldCharacter]. For example `__`
+  final String boldCharacter;
+
+  /// If you want to use an alternative italic character (Default: `*`),
+  /// assign a custom [String] to [italicCharacter]. For example `_`
+  final String italicCharacter;
+
+  /// If you want to use an alternative code character (Default: `` ``` ``),
+  /// assign a custom [String] to [codeCharacter]. For example ``` ` ```
+  final String codeCharacter;
+
+  /// If you want to use an alternative bulleted list character (Default: `-`),
+  /// assign a custom [String] to [bulletedListCharacter]. For example `*`
+  final String bulletedListCharacter;
+
+  /// If you want to use an alternative horizontal rule character (Default: `---`),
+  /// assign a custom [String] to [horizontalRuleCharacter]. For example `***`
+  final String horizontalRuleCharacter;
+
+  /// Hide the heading button by setting [hideHeading] to `true`.
+  final bool hideHeading;
+
+  /// Hide the bold button by setting [hideBold] to `true`.
+  final bool hideBold;
+
+  /// Hide the italic button by setting [hideItalic] to `true`.
+  final bool hideItalic;
+
+  /// Hide the strikethrough button by setting [hideStrikethrough] to `true`.
+  final bool hideStrikethrough;
+
+  /// Hide the link button by setting [hideLink] to `true`.
+  final bool hideLink;
+
+  /// Hide the image button by setting [hideImage] to `true`.
+  final bool hideImage;
+
+  /// Hide the code button by setting [hideCode] to `true`.
+  final bool hideCode;
+
+  /// Hide the bulleted list button by setting [hideBulletedList] to `true`.
+  final bool hideBulletedList;
+
+  /// Hide the numbered list button by setting [hideNumberedList] to `true`.
+  final bool hideNumberedList;
+
+  /// Hide the checkbox button by setting [hideCheckbox] to `true`.
+  final bool hideCheckbox;
+
+  /// Hide the quote button by setting [hideQuote] to `true`.
+  final bool hideQuote;
+
+  /// Disable all tooltips by setting [showTooltips] to `false`. Default: `true`.
+  final bool showTooltips;
+
+  /// Hide the horizontal rule button by setting [hideHorizontalRule] to `true`.
+  final bool hideHorizontalRule;
+
+  /// Set a custom tooltip [String] for the heading button. Leave blank `''` to disable tooltip.
+  final String headingTooltip;
+
+  /// Set a custom tooltip [String] for the bold button. Leave blank `''` to disable tooltip.
+  final String boldTooltip;
+
+  /// Set a custom tooltip [String] for the italic button. Leave blank `''` to disable tooltip.
+  final String italicTooltip;
+
+  /// Set a custom tooltip [String] for the strikethrough button. Leave blank `''` to disable tooltip.
+  final String strikethroughTooltip;
+
+  /// Set a custom tooltip [String] for the link button. Leave blank `''` to disable tooltip.
+  final String linkTooltip;
+
+  /// Set a custom tooltip [String] for the image button. Leave blank `''` to disable tooltip.
+  final String imageTooltip;
+
+  /// Set a custom tooltip [String] for the code button. Leave blank `''` to disable tooltip.
+  final String codeTooltip;
+
+  /// Set a custom tooltip [String] for the bulleted list button. Leave blank `''` to disable tooltip.
+  final String bulletedListTooltip;
+
+  /// Set a custom tooltip [String] for the numbered list button. Leave blank `''` to disable tooltip.
+  final String numberedListTooltip;
+
+  /// Set a custom tooltip [String] for the checkbox button. Leave blank `''` to disable tooltip.
+  final String checkboxTooltip;
+
+  /// Set a custom tooltip [String] for the quote button. Leave blank `''` to disable tooltip.
+  final String quoteTooltip;
+
+  /// Set a custom tooltip [String] for the horizontal rule button. Leave blank `''` to disable tooltip.
+  final String horizontalRuleTooltip;
+
+  @override
+  State<MarkdownToolbar> createState() => MarkdownToolbarState();
+}
+
+class MarkdownToolbarState extends State<MarkdownToolbar> {
+  var isCollapsed = false;
+
+  final TextEditingController _includedController = TextEditingController();
+  late final FocusNode _includedFocusNode;
+
+  @override
+  void initState() {
+    if (widget.useIncludedTextField) {
+      _includedController.addListener(() => setState(() {}));
+      _includedFocusNode = FocusNode();
+    }
+
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    if (widget.useIncludedTextField) {
+      _includedController.dispose();
+      _includedFocusNode.dispose();
+    }
+
+    super.dispose();
+  }
+
+  Widget _buildToolbarItem({
+    required IconData icon,
+    required VoidCallback? onPressed,
+    required String tooltip,
+    bool dropdown = false,
+    List<DropdownMenuItem<int>> dropdownItems = const [],
+    String? dropdownString,
+    Function(int)? onDropdownButtonSelect,
+  }) {
+    return Tooltip(
+      message: tooltip,
+      child: dropdown
+          ? SizedBox(
+              width: widget.width,
+              height: widget.height,
+              child: IconButton(
+                style: IconButton.styleFrom(
+                  backgroundColor: widget.backgroundColor,
+                  padding: const EdgeInsets.all(0),
+                  shape:
+                      RoundedRectangleBorder(borderRadius: widget.borderRadius),
+                ),
+                onPressed: () {},
+                icon: Stack(
+                  alignment: AlignmentDirectional.center,
+                  children: [
+                    dropdownString != null
+                        ? Text(
+                            dropdownString,
+                            style: TextStyle(
+                                color: widget.iconColor,
+                                fontSize: 16.0 * widget.iconSize / 20),
+                          )
+                        : Icon(
+                            icon,
+                            color: widget.iconColor,
+                            size: widget.iconSize,
+                          ),
+                    ClipRRect(
+                      borderRadius: widget.borderRadius,
+                      child: Material(
+                        color: Colors.transparent,
+                        child: DropdownButtonHideUnderline(
+                          child: DropdownButton(
+                            isExpanded: true,
+                            items: dropdownItems,
+                            onChanged: (option) {
+                              if (onDropdownButtonSelect != null) {
+                                onDropdownButtonSelect(option ?? 0);
+                              }
+                            },
+                            icon: Container(),
+                          ),
+                        ),
+                      ),
+                    )
+                  ],
+                ),
+              ),
+            )
+          : SizedBox(
+              width: widget.width,
+              height: widget.height,
+              child: IconButton(
+                style: IconButton.styleFrom(
+                  backgroundColor: widget.backgroundColor,
+                  foregroundColor: widget.iconColor,
+                  padding: const EdgeInsets.all(0),
+                  shape:
+                      RoundedRectangleBorder(borderRadius: widget.borderRadius),
+                ),
+                onPressed: dropdown ? null : onPressed,
+                icon: Icon(
+                  icon,
+                  color: widget.iconColor,
+                  size: widget.iconSize,
+                ),
+              ),
+            ),
+    );
+  }
+
+  Widget _buildCollapseItem() {
+    return SizedBox(
+      width: widget.width,
+      height: widget.height,
+      child: IconButton(
+        style: IconButton.styleFrom(
+          backgroundColor: widget.backgroundColor,
+          foregroundColor: widget.iconColor,
+          padding: const EdgeInsets.all(0),
+          shape: RoundedRectangleBorder(borderRadius: widget.borderRadius),
+        ),
+        onPressed: () => setState(() {
+          isCollapsed = !isCollapsed;
+        }),
+        icon: RotatedBox(
+          quarterTurns: widget.flipCollapseButtonIcon == true ? 3 : 1,
+          child: Icon(
+            isCollapsed ? Icons.expand_more : Icons.expand_less,
+            color: widget.iconColor,
+            size: widget.iconSize + 4,
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _toolbarItems({
+    required bool useIncludedTextField,
+    required bool collapsable,
+    required bool showTooltips,
+    required bool hideHeading,
+    required bool hideBold,
+    required bool hideItalic,
+    required bool hideStrikethrough,
+    required bool hideLink,
+    required bool hideImage,
+    required bool hideCode,
+    required bool hideBulletedList,
+    required bool hideNumberedList,
+    required bool hideCheckbox,
+    required bool hideQuote,
+    required bool hideHorizontalRule,
+    required String headingTooltip,
+    required String boldTooltip,
+    required String italicTooltip,
+    required String strikethroughTooltip,
+    required String linkTooltip,
+    required String imageTooltip,
+    required String codeTooltip,
+    required String bulletedListTooltip,
+    required String numberedListTooltip,
+    required String checkboxTooltip,
+    required String quoteTooltip,
+    required String horizontalRuleTooltip,
+  }) {
+    if (collapsable && isCollapsed) {
+      return [
+        _buildCollapseItem(),
+      ];
+    } else {
+      return [
+        if (collapsable && !widget.alignCollapseButtonEnd) _buildCollapseItem(),
+        if (!hideHeading)
+          _buildToolbarItem(
+            icon: Icons.h_mobiledata,
+            tooltip: showTooltips == true ? headingTooltip : '',
+            onPressed: () => onToolbarItemPressed(
+              markdownToolbarOption: MarkdownToolbarOption.heading,
+            ),
+            onDropdownButtonSelect: (int option) => onHeadingPressed(option),
+            dropdown: true,
+            dropdownItems: [
+              DropdownMenuItem<int>(
+                value: 0,
+                child: Text(
+                  'H1',
+                  style: TextStyle(
+                    color: widget.dropdownTextColor,
+                    fontWeight: FontWeight.w500,
+                    fontSize: 20.0,
+                  ),
+                ),
+              ),
+              DropdownMenuItem<int>(
+                value: 1,
+                child: Text(
+                  'H2',
+                  style: TextStyle(
+                    color: widget.dropdownTextColor,
+                    fontWeight: FontWeight.w500,
+                    fontSize: 19.0,
+                  ),
+                ),
+              ),
+              DropdownMenuItem<int>(
+                value: 2,
+                child: Text(
+                  'H3',
+                  style: TextStyle(
+                    color: widget.dropdownTextColor,
+                    fontWeight: FontWeight.w500,
+                    fontSize: 18.0,
+                  ),
+                ),
+              ),
+              DropdownMenuItem<int>(
+                value: 3,
+                child: Text(
+                  'H4',
+                  style: TextStyle(
+                    color: widget.dropdownTextColor,
+                    fontWeight: FontWeight.w500,
+                    fontSize: 17.0,
+                  ),
+                ),
+              ),
+              DropdownMenuItem<int>(
+                value: 4,
+                child: Text(
+                  'H5',
+                  style: TextStyle(
+                    color: widget.dropdownTextColor,
+                    fontWeight: FontWeight.w500,
+                    fontSize: 16.0,
+                  ),
+                ),
+              ),
+              DropdownMenuItem<int>(
+                value: 5,
+                child: Text(
+                  'H6',
+                  style: TextStyle(
+                    color: widget.dropdownTextColor,
+                    fontWeight: FontWeight.w500,
+                    fontSize: 15.0,
+                  ),
+                ),
+              ),
+            ],
+            dropdownString: 'H1',
+          ),
+        if (!hideBold)
+          _buildToolbarItem(
+            icon: Icons.format_bold,
+            tooltip: showTooltips == true ? boldTooltip : '',
+            onPressed: () => onBoldPressed(),
+          ),
+        if (!hideItalic)
+          _buildToolbarItem(
+            icon: Icons.format_italic,
+            tooltip: showTooltips == true ? italicTooltip : '',
+            onPressed: () => onItalicPressed(),
+          ),
+        if (!hideStrikethrough)
+          _buildToolbarItem(
+            icon: Icons.format_strikethrough,
+            tooltip: showTooltips == true ? strikethroughTooltip : '',
+            onPressed: () => onStrikethroughPressed(),
+          ),
+        if (!hideLink)
+          _buildToolbarItem(
+            icon: Icons.link,
+            tooltip: showTooltips == true ? linkTooltip : '',
+            onPressed: () => onLinkPressed(),
+          ),
+        if (!hideImage)
+          _buildToolbarItem(
+            icon: Icons.image,
+            tooltip: showTooltips == true ? imageTooltip : '',
+            onPressed: () => onImagePressed(),
+          ),
+        if (!hideCode)
+          _buildToolbarItem(
+            icon: Icons.code,
+            tooltip: showTooltips == true ? codeTooltip : '',
+            onPressed: () => onCodePressed(),
+          ),
+        if (!hideBulletedList)
+          _buildToolbarItem(
+            icon: Icons.format_list_bulleted,
+            tooltip: showTooltips == true ? bulletedListTooltip : '',
+            onPressed: () => onUnorderedListPressed(),
+          ),
+        if (!hideNumberedList)
+          _buildToolbarItem(
+            icon: Icons.format_list_numbered,
+            tooltip: showTooltips == true ? numberedListTooltip : '',
+            onPressed: () => onOrderedListPressed(),
+          ),
+        if (!hideCheckbox)
+          _buildToolbarItem(
+            icon: Icons.check_box,
+            tooltip: showTooltips == true ? checkboxTooltip : '',
+            onPressed: () => onToolbarItemPressed(
+              markdownToolbarOption: MarkdownToolbarOption.checkbox,
+            ),
+            onDropdownButtonSelect: (int option) => onCheckboxPressed(option),
+            dropdown: true,
+            dropdownItems: [
+              DropdownMenuItem<int>(
+                value: 0,
+                child: Icon(
+                  Icons.check_box_outline_blank,
+                  color: widget.dropdownTextColor,
+                ),
+              ),
+              DropdownMenuItem<int>(
+                value: 1,
+                child: Icon(
+                  Icons.check_box,
+                  color: widget.dropdownTextColor,
+                ),
+              ),
+            ],
+          ),
+        if (!hideQuote)
+          _buildToolbarItem(
+            icon: Icons.format_quote,
+            tooltip: showTooltips == true ? quoteTooltip : '',
+            onPressed: () => onQuotePressed(),
+          ),
+        if (!hideHorizontalRule)
+          _buildToolbarItem(
+            icon: Icons.horizontal_rule,
+            tooltip: showTooltips == true ? horizontalRuleTooltip : '',
+            onPressed: () => onHorizontalRulePressed(),
+          ),
+        if (collapsable && widget.alignCollapseButtonEnd) _buildCollapseItem(),
+      ];
+    }
+  }
+
+  void onHeadingPressed(int option) => onToolbarItemPressed(
+      option: option, markdownToolbarOption: MarkdownToolbarOption.heading);
+
+  void onBoldPressed() =>
+      onToolbarItemPressed(markdownToolbarOption: MarkdownToolbarOption.bold);
+
+  void onItalicPressed() =>
+      onToolbarItemPressed(markdownToolbarOption: MarkdownToolbarOption.italic);
+
+  void onStrikethroughPressed() => onToolbarItemPressed(
+      markdownToolbarOption: MarkdownToolbarOption.strikethrough);
+
+  void onLinkPressed() =>
+      onToolbarItemPressed(markdownToolbarOption: MarkdownToolbarOption.link);
+
+  void onImagePressed() =>
+      onToolbarItemPressed(markdownToolbarOption: MarkdownToolbarOption.image);
+
+  void onCodePressed() =>
+      onToolbarItemPressed(markdownToolbarOption: MarkdownToolbarOption.code);
+
+  void onUnorderedListPressed() => onToolbarItemPressed(
+      markdownToolbarOption: MarkdownToolbarOption.unorderedList);
+
+  void onOrderedListPressed() => onToolbarItemPressed(
+      markdownToolbarOption: MarkdownToolbarOption.orderedList);
+
+  void onCheckboxPressed(int option) => onToolbarItemPressed(
+      option: option, markdownToolbarOption: MarkdownToolbarOption.checkbox);
+
+  void onQuotePressed() =>
+      onToolbarItemPressed(markdownToolbarOption: MarkdownToolbarOption.quote);
+
+  void onHorizontalRulePressed() => onToolbarItemPressed(
+      markdownToolbarOption: MarkdownToolbarOption.horizontalRule);
+
+  void onToolbarItemPressed({
+    required MarkdownToolbarOption markdownToolbarOption,
+    int? option,
+  }) {
+    widget.useIncludedTextField
+        ? _includedFocusNode.requestFocus()
+        : widget.focusNode?.requestFocus();
+    Format.toolbarItemPressed(
+      markdownToolbarOption: markdownToolbarOption,
+      controller: widget.useIncludedTextField
+          ? _includedController
+          : widget.controller ?? _includedController,
+      selection: widget.useIncludedTextField
+          ? _includedController.selection
+          : widget.controller?.selection ?? _includedController.selection,
+      option: option,
+      customBoldCharacter: widget.boldCharacter,
+      customItalicCharacter: widget.italicCharacter,
+      customCodeCharacter: widget.codeCharacter,
+      customBulletedListCharacter: widget.bulletedListCharacter,
+      customHorizontalRuleCharacter: widget.horizontalRuleCharacter,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Wrap(
+          alignment: widget.alignment,
+          spacing: widget.spacing,
+          runSpacing: widget.runSpacing,
+          children: _toolbarItems(
+            useIncludedTextField: widget.useIncludedTextField,
+            collapsable: widget.collapsable,
+            showTooltips: widget.showTooltips,
+            hideHeading: widget.hideHeading,
+            hideBold: widget.hideBold,
+            hideItalic: widget.hideItalic,
+            hideStrikethrough: widget.hideStrikethrough,
+            hideLink: widget.hideLink,
+            hideImage: widget.hideImage,
+            hideCode: widget.hideCode,
+            hideBulletedList: widget.hideBulletedList,
+            hideNumberedList: widget.hideNumberedList,
+            hideCheckbox: widget.hideCheckbox,
+            hideQuote: widget.hideQuote,
+            hideHorizontalRule: widget.hideHorizontalRule,
+            headingTooltip: widget.headingTooltip,
+            boldTooltip: widget.boldTooltip,
+            italicTooltip: widget.italicTooltip,
+            strikethroughTooltip: widget.strikethroughTooltip,
+            linkTooltip: widget.linkTooltip,
+            imageTooltip: widget.imageTooltip,
+            codeTooltip: widget.codeTooltip,
+            bulletedListTooltip: widget.bulletedListTooltip,
+            numberedListTooltip: widget.numberedListTooltip,
+            checkboxTooltip: widget.checkboxTooltip,
+            quoteTooltip: widget.quoteTooltip,
+            horizontalRuleTooltip: widget.horizontalRuleTooltip,
+          ),
+        ),
+        if (widget.useIncludedTextField) const SizedBox(height: 4.0),
+        if (widget.useIncludedTextField)
+          TextField(
+            controller: widget.useIncludedTextField
+                ? _includedController
+                : widget.controller,
+            focusNode: widget.useIncludedTextField
+                ? _includedFocusNode
+                : widget.focusNode,
+            minLines: 1,
+            maxLines: null,
+            decoration: const InputDecoration(
+              hintText: 'Your markdown text',
+              labelText: 'Text field',
+              border: OutlineInputBorder(),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/components/markdown_bar/parser.dart
+++ b/lib/components/markdown_bar/parser.dart
@@ -1,0 +1,604 @@
+import 'package:flutter/widgets.dart';
+
+enum MarkdownToolbarOption {
+  bold,
+  italic,
+  strikethrough,
+  heading,
+  link,
+  image,
+  code,
+  unorderedList,
+  orderedList,
+  checkbox,
+  quote,
+  horizontalRule,
+}
+
+enum FormatOption {
+  formatStartEnd,
+  formatStart,
+  formatList,
+  formatAddNew,
+}
+
+enum TextApplyOption {
+  selectionHasCharacter,
+  outsideSelectionHasCharacter,
+  noneAddNew,
+}
+
+class Format {
+  Format({
+    required this.formatOption,
+    required this.controller,
+    required this.selection,
+    this.character,
+    this.newLine,
+    this.placeholder = 'Text',
+    this.multipleCharacters,
+    this.multipleCharactersOption,
+    this.orderedList,
+  });
+
+  FormatOption formatOption;
+  TextEditingController controller;
+  TextSelection selection;
+  String? character;
+  bool? newLine;
+  String placeholder = 'Text';
+  List<String>? multipleCharacters;
+  int? multipleCharactersOption;
+  bool? orderedList;
+  late String newText;
+  late String beforeText;
+  late String afterText;
+  late String reversedBeforeText;
+  late String reversedAfterText;
+  late TextApplyOption textApplyOption;
+
+  static void toolbarItemPressed({
+    required MarkdownToolbarOption markdownToolbarOption,
+    required TextEditingController controller,
+    required TextSelection selection,
+    int? option,
+    String? customBoldCharacter,
+    String? customItalicCharacter,
+    String? customCodeCharacter,
+    String? customBulletedListCharacter,
+    String? customHorizontalRuleCharacter,
+  }) {
+    switch (markdownToolbarOption) {
+      case MarkdownToolbarOption.bold:
+        Format(
+          formatOption: FormatOption.formatStartEnd,
+          controller: controller,
+          selection: selection,
+          character: customBoldCharacter ?? '**',
+          placeholder: 'Bold',
+        ).format();
+        break;
+      case MarkdownToolbarOption.italic:
+        Format(
+          formatOption: FormatOption.formatStartEnd,
+          controller: controller,
+          selection: selection,
+          character: customItalicCharacter ?? '*',
+          placeholder: 'Italic',
+        ).format();
+        break;
+      case MarkdownToolbarOption.strikethrough:
+        Format(
+          formatOption: FormatOption.formatStartEnd,
+          controller: controller,
+          selection: selection,
+          character: '~~',
+          placeholder: 'Strikethrough',
+        ).format();
+        break;
+      case MarkdownToolbarOption.code:
+        Format(
+          formatOption: FormatOption.formatStartEnd,
+          controller: controller,
+          selection: selection,
+          character: customCodeCharacter ?? '```',
+          placeholder: 'Code',
+          newLine: true,
+        ).format();
+        break;
+      case MarkdownToolbarOption.heading:
+        Format(
+          formatOption: FormatOption.formatStart,
+          controller: controller,
+          selection: selection,
+          multipleCharacters: [
+            '# ',
+            '## ',
+            '### ',
+            '#### ',
+            '##### ',
+            '###### '
+          ],
+          multipleCharactersOption: option,
+          newLine: true,
+          placeholder: 'Heading',
+        ).format();
+        break;
+      case MarkdownToolbarOption.quote:
+        Format(
+          formatOption: FormatOption.formatStart,
+          controller: controller,
+          selection: selection,
+          character: '> ',
+          newLine: true,
+          placeholder: 'Quote',
+        ).format();
+        break;
+      case MarkdownToolbarOption.unorderedList:
+        Format(
+          formatOption: FormatOption.formatList,
+          controller: controller,
+          selection: selection,
+          character: customBulletedListCharacter != null
+              ? '$customBulletedListCharacter '
+              : '- ',
+          placeholder: 'Bulleted list',
+        ).format();
+        break;
+      case MarkdownToolbarOption.orderedList:
+        Format(
+          formatOption: FormatOption.formatList,
+          controller: controller,
+          selection: selection,
+          orderedList: true,
+          placeholder: 'Numbered list',
+        ).format();
+        break;
+      case MarkdownToolbarOption.checkbox:
+        Format(
+          formatOption: FormatOption.formatList,
+          controller: controller,
+          selection: selection,
+          placeholder: 'Checkbox',
+          multipleCharacters: ['- [ ] ', '- [x] '],
+          multipleCharactersOption: option,
+        ).format();
+        break;
+      case MarkdownToolbarOption.link:
+        formatTextLink(
+          controller: controller,
+          selection: selection,
+        );
+        break;
+      case MarkdownToolbarOption.image:
+        formatImage(
+          controller: controller,
+          selection: selection,
+        );
+        break;
+      case MarkdownToolbarOption.horizontalRule:
+        Format(
+          formatOption: FormatOption.formatAddNew,
+          controller: controller,
+          selection: selection,
+          //newLine: true,
+          character: customHorizontalRuleCharacter ?? '---',
+        ).format();
+        break;
+    }
+  }
+
+  void format() {
+    String selectionText =
+        controller.text.substring(selection.start, selection.end);
+
+    beforeText = controller.text.substring(0, selection.start);
+    afterText =
+        controller.text.substring(selection.end, controller.text.length);
+    reversedBeforeText =
+        String.fromCharCodes(beforeText.runes.toList().reversed);
+    reversedAfterText = String.fromCharCodes(afterText.runes.toList().reversed);
+
+    character = multipleCharacters != null
+        ? multipleCharacters![multipleCharactersOption ?? 0]
+        : character ?? '';
+
+    if (controller.text.isNotEmpty && selectionText.isNotEmpty) {
+      newText = selectionText;
+
+      if (selectionCharacterBool(
+          formatOption: formatOption, selectionText: selectionText)) {
+        selectionHasCharacterFunction(formatOption: formatOption);
+      } else if (outsideSelectionHasCharacterBool(formatOption: formatOption)) {
+        outsideHasCharacterFunction(formatOption: formatOption);
+      } else {
+        addFunction(formatOption: formatOption);
+      }
+
+      applyFunction(formatOption: formatOption);
+    } else {
+      emptyAddNewFunction(formatOption: formatOption);
+    }
+  }
+
+  bool selectionCharacterBool({
+    required FormatOption formatOption,
+    required String selectionText,
+  }) {
+    switch (formatOption) {
+      case FormatOption.formatStartEnd:
+        return selectionText.contains(character!, 0) &&
+            selectionText.contains(character!, 1);
+      case FormatOption.formatStart:
+        //TODO if same -> remove /// if other -> remove AND add new
+        if (multipleCharacters != null) {
+          for (var i = 0; i < multipleCharacters!.length; i++) {
+            if (selectionText.contains(multipleCharacters![i])) {
+              return true;
+            }
+          }
+        }
+        return selectionText.contains(character!);
+      case FormatOption.formatList:
+        var exp = RegExp(r'[0-9]. ');
+        //TODO if same -> remove /// if other -> remove AND add new
+        if (multipleCharacters != null) {
+          for (var i = 0; i < multipleCharacters!.length; i++) {
+            if (selectionText.contains(multipleCharacters![i])) {
+              return true;
+            } else {
+              //return false;
+            }
+          }
+        }
+        return selectionText.contains(orderedList == true ? exp : character!);
+      case FormatOption.formatAddNew:
+        return selectionText.contains(character!);
+    }
+  }
+
+  bool outsideSelectionHasCharacterBool({
+    required FormatOption formatOption,
+  }) {
+    if (formatOption == FormatOption.formatStartEnd) {
+      return beforeText.isNotEmpty &&
+          reversedBeforeText[0] != ' ' &&
+          reversedBeforeText.contains(character!) &&
+          afterText.isNotEmpty &&
+          reversedAfterText[0] != ' ' &&
+          reversedAfterText.contains(character!);
+    } else {
+      return false;
+    }
+  }
+
+  void selectionHasCharacterFunction({
+    required FormatOption formatOption,
+  }) {
+    textApplyOption = TextApplyOption.selectionHasCharacter;
+    switch (formatOption) {
+      case FormatOption.formatStartEnd:
+        newText = controller.text.substring(selection.start, selection.end);
+        newText = newText.replaceAll(character!, '');
+        break;
+      case FormatOption.formatStart:
+        newText = controller.text.substring(selection.start, selection.end);
+        if (multipleCharacters != null) {
+          for (var i = 0; i < multipleCharacters!.length; i++) {
+            if (newText.contains(multipleCharacters![i])) {
+              newText = newText.replaceAll(character![0], '');
+            } else {
+              newText = newText.replaceAll(character!, '');
+              break;
+            }
+          }
+        } else {
+          newText = newText.replaceAll(character!, '');
+        }
+        //newText = newText.replaceAll(character!, '');
+        break;
+      case FormatOption.formatList:
+        newText = controller.text.substring(selection.start, selection.end);
+        var exp = RegExp(r'[0-9]. ');
+
+        var lines = newText.split('\n');
+        var orderedIndex =
+            int.tryParse(lines[0].substring(0, lines[0].indexOf(exp) + 1)) ?? 0;
+
+        if (orderedList == true) {
+          for (var i = 0; i < lines.length; i++) {
+            if (lines[i].isNotEmpty) {
+              lines[i] = lines[i].replaceAll('$orderedIndex. ', '');
+              orderedIndex++;
+            }
+          }
+        } else {
+          if (multipleCharacters != null) {
+            for (var i = 0; i < multipleCharacters!.length; i++) {
+              for (var j = 0; j < lines.length; j++) {
+                if (lines[j].contains(multipleCharacters![i])) {
+                  lines[j] = lines[j].replaceAll(multipleCharacters![i], '');
+                } else {
+                  for (var i = 0; i < lines.length; i++) {
+                    lines[i] = lines[i].replaceAll(character!, '');
+                  }
+                }
+              }
+            }
+          } else {
+            for (var i = 0; i < lines.length; i++) {
+              lines[i] = lines[i].replaceAll(character!, '');
+            }
+          }
+        }
+
+        newText = lines.join('\n');
+        break;
+      case FormatOption.formatAddNew:
+        newText = controller.text.substring(selection.start, selection.end);
+        newText = newText.replaceAll(character!, '');
+        break;
+    }
+  }
+
+  void outsideHasCharacterFunction({
+    required FormatOption formatOption,
+  }) {
+    textApplyOption = TextApplyOption.outsideSelectionHasCharacter;
+    if (formatOption == FormatOption.formatStartEnd) {
+      reversedBeforeText = reversedBeforeText.replaceFirst(character!, '');
+      beforeText =
+          String.fromCharCodes(reversedBeforeText.runes.toList().reversed);
+      afterText = afterText.replaceFirst(character!, '');
+    }
+  }
+
+  void addFunction({
+    required FormatOption formatOption,
+  }) {
+    textApplyOption = TextApplyOption.noneAddNew;
+    switch (formatOption) {
+      case FormatOption.formatStartEnd:
+        newText = controller.text.substring(selection.start, selection.end);
+        newLine == true
+            ? newText = '\n$character\n$newText\n$character'
+            : newText = '$character$newText$character';
+        break;
+      case FormatOption.formatStart:
+        newText = controller.text.substring(selection.start, selection.end);
+        newLine == true
+            ? newText = '$character$newText'
+            : newText = '$character$newText';
+        break;
+      case FormatOption.formatList:
+        newText = controller.text.substring(selection.start, selection.end);
+        var lines = newText.split('\n');
+        var orderedIndex = 0;
+
+        for (var i = 0; i < lines.length; i++) {
+          if (lines[i].isNotEmpty) {
+            if (orderedList == true) {
+              lines[i] = '${orderedIndex + 1}. ${lines[i]}';
+              orderedIndex++;
+            } else {
+              lines[i] = '$character${lines[i]}';
+            }
+          }
+        }
+
+        newText = lines.join('\n');
+        break;
+      case FormatOption.formatAddNew:
+        newLine == true
+            ? newText = '\n$character$newText\n'
+            : newText = '$character$newText';
+        newText = character!;
+        break;
+    }
+  }
+
+  void applyFunction({
+    required FormatOption formatOption,
+  }) {
+    var baseOffset = 0;
+    var extentOffset = 0;
+    switch (formatOption) {
+      case FormatOption.formatStartEnd:
+        newText = '$beforeText$newText$afterText';
+        controller.text = newText;
+
+        if (textApplyOption == TextApplyOption.selectionHasCharacter ||
+            textApplyOption == TextApplyOption.outsideSelectionHasCharacter) {
+          baseOffset = selection.start - character!.length;
+          extentOffset = selection.end - character!.length;
+        } else if (textApplyOption == TextApplyOption.noneAddNew) {
+          baseOffset = selection.start + character!.length;
+          extentOffset = selection.end + character!.length;
+          if (newLine != null) {
+            baseOffset += 2;
+            extentOffset += 2;
+          }
+        }
+        break;
+      case FormatOption.formatStart:
+        newText = '$beforeText$newText$afterText';
+        controller.text = newText;
+        if (textApplyOption == TextApplyOption.selectionHasCharacter ||
+            textApplyOption == TextApplyOption.outsideSelectionHasCharacter) {
+          baseOffset = selection.start - character!.length;
+          extentOffset = selection.end - character!.length;
+        } else if (textApplyOption == TextApplyOption.noneAddNew) {
+          baseOffset = selection.start + character!.length;
+          extentOffset = selection.end + character!.length;
+        }
+        break;
+      case FormatOption.formatList:
+        var lines = newText.split('\n');
+        var index = 0;
+        for (var i = 0; i < lines.length; i++) {
+          if (lines[i].isNotEmpty) {
+            index++;
+          }
+        }
+        if (textApplyOption == TextApplyOption.selectionHasCharacter ||
+            textApplyOption == TextApplyOption.outsideSelectionHasCharacter) {
+          if (orderedList == true) {
+            baseOffset = selection.end - 3 * index;
+            extentOffset = selection.end - 3 * index;
+          } else {
+            baseOffset = selection.end - 2 * index;
+            extentOffset = selection.end - 2 * index;
+          }
+        } else if (textApplyOption == TextApplyOption.noneAddNew) {
+          if (orderedList == true) {
+            baseOffset = selection.end + 3 * index;
+            extentOffset = selection.end + 3 * index;
+          } else {
+            baseOffset = selection.end + 2 * index;
+            extentOffset = selection.end + 2 * index;
+          }
+        }
+        newText = '$beforeText$newText$afterText';
+        controller.text = newText;
+        break;
+      case FormatOption.formatAddNew:
+        newText = '$beforeText$newText$afterText';
+        controller.text = newText;
+
+        if (textApplyOption == TextApplyOption.selectionHasCharacter ||
+            textApplyOption == TextApplyOption.outsideSelectionHasCharacter) {
+          baseOffset = selection.start - character!.length;
+          extentOffset = selection.start - character!.length;
+        } else if (textApplyOption == TextApplyOption.noneAddNew) {
+          baseOffset = selection.start + character!.length;
+          extentOffset = selection.start + character!.length;
+        }
+        break;
+    }
+
+    if (baseOffset >= controller.text.length) {
+      baseOffset = controller.text.length;
+    }
+    if (extentOffset >= controller.text.length) {
+      extentOffset = controller.text.length;
+    }
+    if (baseOffset <= 0) baseOffset = 0;
+    if (extentOffset <= 0) extentOffset = 0;
+    controller.selection = TextSelection(
+      baseOffset: baseOffset,
+      extentOffset: extentOffset,
+    );
+  }
+
+  void emptyAddNewFunction({
+    required FormatOption formatOption,
+  }) {
+    var baseOffset = 0;
+    var extentOffset = 0;
+    switch (formatOption) {
+      case FormatOption.formatStartEnd:
+        var newText = character;
+        var beforeText = controller.text.substring(0, selection.start);
+        var afterText =
+            controller.text.substring(selection.end, controller.text.length);
+        controller.text = '$beforeText$newText$placeholder$newText$afterText';
+        baseOffset = selection.start + character!.length;
+        extentOffset = selection.end + placeholder.length + character!.length;
+        break;
+      case FormatOption.formatStart:
+        var newText = character;
+        var beforeText = controller.text.substring(0, selection.start);
+        var afterText =
+            controller.text.substring(selection.end, controller.text.length);
+        controller.text = '$beforeText$newText$placeholder$afterText';
+
+        baseOffset = selection.start + character!.length;
+        extentOffset = selection.end + placeholder.length + character!.length;
+        break;
+      case FormatOption.formatList:
+        var newText = orderedList == true ? '1. ' : character;
+        var beforeText = controller.text.substring(0, selection.start);
+        var afterText =
+            controller.text.substring(selection.end, controller.text.length);
+        controller.text = '$beforeText$newText$placeholder$afterText';
+        baseOffset = selection.start + newText!.length;
+        extentOffset = selection.end + placeholder.length + newText.length;
+        break;
+      case FormatOption.formatAddNew:
+        newLine == true ? newText = '\n$character\n' : newText = character!;
+        controller.text = '$beforeText$newText$afterText';
+        baseOffset = selection.start + character!.length + 1;
+        extentOffset = selection.start + character!.length + 1;
+        break;
+    }
+    if (baseOffset >= controller.text.length) {
+      baseOffset = controller.text.length;
+    }
+    if (extentOffset >= controller.text.length) {
+      extentOffset = controller.text.length;
+    }
+    if (baseOffset <= 0) baseOffset = 0;
+    if (extentOffset <= 0) extentOffset = 0;
+    controller.selection = TextSelection(
+      baseOffset: baseOffset,
+      extentOffset: extentOffset,
+    );
+  }
+}
+
+void formatTextLink({
+  required TextEditingController controller,
+  required TextSelection selection,
+}) {
+  String selectionText =
+      controller.text.substring(selection.start, selection.end);
+  String placeholder = 'My Link text';
+  String placeholderEnd = 'https://example.com';
+
+  if (controller.text.isNotEmpty && selectionText.isNotEmpty) {
+    var newText = selectionText;
+
+    var beforeText = controller.text.substring(0, selection.start);
+    var afterText =
+        controller.text.substring(selection.end, controller.text.length);
+
+    newText = '[$newText]($placeholderEnd)';
+    newText = '$beforeText$newText$afterText';
+
+    controller.text = newText;
+
+    controller.selection = TextSelection(
+        baseOffset:
+            selection.start + 3 + selectionText.length + 'https://'.length,
+        extentOffset: selection.end + placeholderEnd.length + 3);
+  } else {
+    var beforeText = controller.text.substring(0, selection.start);
+    var afterText =
+        controller.text.substring(selection.end, controller.text.length);
+    controller.text = '$beforeText[$placeholder]($placeholderEnd)$afterText';
+
+    controller.selection = TextSelection(
+        baseOffset:
+            selection.start + 3 + placeholder.length + 'https://'.length,
+        extentOffset:
+            selection.end + placeholder.length + 3 + placeholderEnd.length);
+  }
+}
+
+void formatImage({
+  required TextEditingController controller,
+  required TextSelection selection,
+}) {
+  String altPlaceholder = 'Alt text';
+  String linkPlaceholder = '/link/to/picture.jpg';
+
+  var beforeText = controller.text.substring(0, selection.start);
+  var afterText =
+      controller.text.substring(selection.end, controller.text.length);
+  controller.text = '$beforeText![$altPlaceholder]($linkPlaceholder)$afterText';
+
+  controller.selection = TextSelection(
+      baseOffset: selection.start + 4 + altPlaceholder.length,
+      extentOffset:
+          selection.start + altPlaceholder.length + 4 + linkPlaceholder.length);
+}

--- a/lib/pages/edit/edit_logic.dart
+++ b/lib/pages/edit/edit_logic.dart
@@ -35,11 +35,15 @@ class EditLogic extends GetxController {
   final EditState state = EditState();
 
   //标题
-  late TextEditingController titleTextEditingController =
+  late final TextEditingController titleTextEditingController =
       TextEditingController();
 
   //编辑器控制器
   late QuillController quillController;
+
+  // markdown控制器
+  late final TextEditingController markdownTextEditingController =
+      TextEditingController();
 
   //聚焦对象
   late FocusNode contentFocusNode = FocusNode();
@@ -93,6 +97,7 @@ class EditLogic extends GetxController {
     titleFocusNode.dispose();
     contentFocusNode.dispose();
     quillController.dispose();
+    markdownTextEditingController.dispose();
     _timer?.cancel();
     _timer = null;
     super.onClose();
@@ -563,5 +568,13 @@ class EditLogic extends GetxController {
       }
     }
     update(['CategoryName']);
+  }
+
+  void renderMarkdown() {
+    state.renderMarkdown.value = !state.renderMarkdown.value;
+  }
+
+  void focusContent() {
+    if (!contentFocusNode.hasFocus) contentFocusNode.requestFocus();
   }
 }

--- a/lib/pages/edit/edit_state.dart
+++ b/lib/pages/edit/edit_state.dart
@@ -53,6 +53,9 @@ class EditState {
   // 日记的类型
   late DiaryType type;
 
+  // 是否渲染markdown
+  RxBool renderMarkdown = false.obs;
+
   // 自动获取天气
   bool get autoWeather => PrefUtil.getValue<bool>('autoWeather')!;
 

--- a/lib/pages/home/home_view.dart
+++ b/lib/pages/home/home_view.dart
@@ -220,7 +220,7 @@ class HomePage extends StatelessWidget {
             height: 56 +
                 8 +
                 56 +
-                ((46 + 8) * 2 - 56 - 8) * (logic.fabAnimation.value),
+                ((46 + 8) * 3 - 56 - 8) * (logic.fabAnimation.value),
             child: child,
           );
         },
@@ -229,13 +229,13 @@ class HomePage extends StatelessWidget {
           clipBehavior: Clip.none,
           children: [
             buildToTopButton(),
-            // buildAnimatedActionButton(
-            //     label: l10n.homeNewDiaryMarkdown,
-            //     onTap: () async {
-            //       await logic.toEditPage(type: DiaryType.markdown);
-            //     },
-            //     iconData: FontAwesomeIcons.markdown,
-            //     index: 3),
+            buildAnimatedActionButton(
+                label: l10n.homeNewDiaryMarkdown,
+                onTap: () async {
+                  await logic.toEditPage(type: DiaryType.markdown);
+                },
+                iconData: FontAwesomeIcons.markdown,
+                index: 3),
             buildAnimatedActionButton(
                 label: l10n.homeNewDiaryPlainText,
                 onTap: () async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -522,10 +522,10 @@ packages:
     dependency: transitive
     description:
       name: dbus
-      sha256: "365c771ac3b0e58845f39ec6deebc76e3276aa9922b0cc60840712094d9047ac"
+      sha256: "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   device_info_plus:
     dependency: "direct main"
     description:
@@ -1515,21 +1515,13 @@ packages:
     source: hosted
     version: "0.1.3-main.0"
   markdown:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: markdown
       sha256: "935e23e1ff3bc02d390bad4d4be001208ee92cc217cb5b5a6c19bc14aaa318c1"
       url: "https://pub.dev"
     source: hosted
     version: "7.3.0"
-  markdown_toolbar:
-    dependency: "direct main"
-    description:
-      name: markdown_toolbar
-      sha256: "5f4e2548afe96cc2ccdad22da87d380e4726d2d3385ddbb7035aa94daf9a4d47"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.0"
   markdown_widget:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -113,8 +113,8 @@ dependencies:
   tutorial_coach_mark: 1.2.12
   adaptive_dialog: 2.4.0
   flutter_inappwebview: 6.1.5
-  markdown_toolbar: 0.5.0
   sensors_plus: 6.1.1
+  markdown: 7.3.0
 
 
 dev_dependencies:


### PR DESCRIPTION
- Add markdown_bar component for markdown editing.
- Update edit page to support markdown diary type.
- Update home page floating button to include markdown diary.
- Update edit_logic to include markdown controller.
- Update markdown and remove markdown_toolbar package.
- Add support to preview markdown.
- Add support to markdown_bar for markdown editing.
- Add support to markdown parser for markdown editing.
- Update home page floating button to include markdown diary.