### PR TITLE
fix(cliff): skip release commits and honour a Changelog: skip footer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Full-repo verification = the four Lint & Test commands above. `flutter test` at 
 
 **Melos**: `melos bootstrap` activates the workspace and regenerates IDE module files; it runs no codegen. `melos list` / `melos run <script> --category <layer>` filter by layer.
 
-**Release**: `tool/release.dart` bumps `mobile/pubspec.yaml`, prepends a git-cliff section to `CHANGELOG.md` for review, opens the `chore(release): X.Y.Z` PR and dispatches `build.yml` from the release branch. The build reads the version from the pubspec and the notes from the changelog section, then leaves a **draft** release — no tag exists yet. Merging the PR fires `publish-release.yml`, which undrafts it, which is what creates the tag, at the squash commit. Changelog generation never runs in CI.
+**Release**: `tool/release.dart` bumps `mobile/pubspec.yaml`, prepends a git-cliff section to `CHANGELOG.md` for review, opens the `chore(release): X.Y.Z` PR and dispatches `build.yml` from the release branch. The build reads the version from the pubspec and the notes from the changelog section, then leaves a **draft** release — no tag exists yet. Merging the PR fires `publish-release.yml`, which undrafts it, which is what creates the tag, at the squash commit. Changelog generation never runs in CI. To keep a PR out of the changelog, put `Changelog: skip` in the squashed commit body, or name it with one of the skipped scopes (`chore(deps|readme|pr|pull)`); the release commit itself is skipped by `chore(release)`.
 
 **Versions** are exact-pinned everywhere; the root `melos` caret is the only exception.
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -32,6 +32,7 @@ split_commits = false
 commit_preprocessors = [
 ]
 commit_parsers = [
+  { footer = "^Changelog:\\s*skip", skip = true },
   { message = "^feat", group = "<!-- 0 -->🚀 Features" },
   { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
   { message = "^doc", group = "<!-- 3 -->📚 Documentation" },
@@ -39,7 +40,7 @@ commit_parsers = [
   { message = "^refactor", group = "<!-- 2 -->🚜 Refactor" },
   { message = "^style", group = "<!-- 5 -->🎨 Styling" },
   { message = "^test", group = "<!-- 6 -->🧪 Testing" },
-  { message = "^chore\\(release\\): prepare for", skip = true },
+  { message = "^chore\\(release\\)", skip = true },
   { message = "^chore\\(deps.*\\)", skip = true },
   { message = "^chore\\(pr\\)", skip = true },
   { message = "^chore\\(pull\\)", skip = true },


### PR DESCRIPTION
`chore(release): 2.8.1` showed up in the generated changelog for the next release. The existing skip rule was `^chore\(release\): prepare for`, which does not match the subject `tool/release.dart` writes.

- Broaden that rule to `^chore\(release\)`.
- Add `{ footer = "^Changelog:\s*skip", skip = true }` so an individual PR can opt out without being renamed.

The footer rule is placed first on purpose: git-cliff takes the first matching parser, so a `feat:` subject would be grouped before the footer was ever read. Verified both ways against a scratch repo using this exact config — a `feat(...)` commit carrying the footer is skipped, and a `chore(release): 0.2.0` commit is skipped.

---
https://claude.ai/code/session_01WJVLaszqF8FSo5hJexPePW